### PR TITLE
Fix quote handling in connector name

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -162,7 +162,7 @@ module.exports = yeoman.generators.Base.extend({
 
     if (!this.options.demo) {
       this.prompt(prompts, function (props) {
-        props.name = props.name.replace(/\"/g, '\\"');
+        props.name = props.name.replace(/\'/g, '&#39;');
         props.appname = _.slugify(props.name);
 
         if (props.hasInput) {

--- a/test/test-app.js
+++ b/test/test-app.js
@@ -300,6 +300,7 @@ describe('web-data-connector:needs-proxy', function () {
 describe('web-data-connector:valid-javascript', function () {
   var combinations = {
         default: {},
+        containsBadChars: {name: 'company\'s data'},
         justNeedsProxy: {needsProxy: true},
         tokenAuth: {authentication: 'token'},
         basicAuth: {authentication: 'basic'},

--- a/test/test-app.js
+++ b/test/test-app.js
@@ -300,7 +300,7 @@ describe('web-data-connector:needs-proxy', function () {
 describe('web-data-connector:valid-javascript', function () {
   var combinations = {
         default: {},
-        containsBadChars: {name: 'company\'s data'},
+        containsBadChars: {name: 'company\'s "data"'},
         justNeedsProxy: {needsProxy: true},
         tokenAuth: {authentication: 'token'},
         basicAuth: {authentication: 'basic'},


### PR DESCRIPTION
Replaces single quotes with HTML entity so generated JS is valid.

Closes #40.