### PR TITLE
Add tether as dependency

### DIFF
--- a/generators/app/templates/Gruntfile.js
+++ b/generators/app/templates/Gruntfile.js
@@ -23,6 +23,7 @@ module.exports = function(grunt) {
         src: [
           'bower_components/jquery/dist/jquery.js',
           'bower_components/tableau/dist/*.js',
+          'bower_components/tether/dist/js/tether.js',
           'bower_components/bootstrap/dist/js/bootstrap.js',
           'src/wrapper.js',
           'src/**/*.js'

--- a/generators/app/templates/_bower.json
+++ b/generators/app/templates/_bower.json
@@ -3,6 +3,7 @@
   "version": "0.0.0",
   "dependencies": {
     "bootstrap": "~4.0.0",
-    "jquery": "~1.11"
+    "jquery": "~1.11",
+    "tether": "~1.3.2"
   }
 }


### PR DESCRIPTION
Sometime between when we first wrote this and now, Bootstrap v4 alphas started depending on Tether for tooltips.  Simplest fix, for now, is to just require tether.  Maybe in the future, we'll remove the bootstrap dependency (esp. w/the 10.0 unification styles coming soon).

Closes #48.