### PR TITLE
Fix generator on node 6+

### DIFF
--- a/generators/app/templates/Gruntfile.js
+++ b/generators/app/templates/Gruntfile.js
@@ -18,7 +18,7 @@ module.exports = function(grunt) {
     concat: {
       js: {
         options: {
-          separator: ';'
+          separator: ';\n'
         },
         src: [
           'bower_components/es6-promise/es6-promise.js',

--- a/generators/app/templates/_bower.json
+++ b/generators/app/templates/_bower.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "bootstrap": "~4.0.0",
     "jquery": "~1.11",
-    "tether": "~1.3.2",
+    "tether": "~1.4.0",
     "wdcw": "~2.0.0"
   }
 }


### PR DESCRIPTION
- Resolves an issue when running `grunt` on a freshly generated WDC using node 6+.
- Also fixes bower dependency conflict for tether.

Addresses #59.